### PR TITLE
fix tests on Windows

### DIFF
--- a/rwt/tests/test_launch.py
+++ b/rwt/tests/test_launch.py
@@ -11,11 +11,11 @@ from rwt import launch
 
 
 def test_with_path(tmpdir, capfd):
-	params = ['-c', 'import sys; print(sys.path)']
+	params = ['-c', 'import sys; sys.stdout.write("\\n".join(sys.path))']
 	res = launch.with_path(str(tmpdir), params)
 	assert res == 0
 	out, err = capfd.readouterr()
-	assert str(tmpdir) in out
+	assert tmpdir in out.split(os.linesep)
 
 
 def test_with_path_result_code(tmpdir):
@@ -29,7 +29,7 @@ def test_with_path_result_code(tmpdir):
 
 @pytest.mark.xfail(reason="cleanup can't occur with execv; #4")
 def test_with_path_overlay(tmpdir, capfd):
-	params = ['-c', 'import sys; print(sys.path)']
+	params = ['-c', 'import sys; sys.stdout.write("\\n".join(sys.path))']
 	# launch subprocess so as not to overlay the test process
 	script = textwrap.dedent("""
 		import rwt.launch
@@ -38,7 +38,7 @@ def test_with_path_overlay(tmpdir, capfd):
 	""").strip().replace('\n', '; ').format(tmpdir=str(tmpdir), params=params)
 	subprocess.Popen([sys.executable, '-c', script]).wait()
 	out, err = capfd.readouterr()
-	assert str(tmpdir) in out
+	assert str(tmpdir) in out.split(os.linesep)
 	assert "cleanup" in out
 
 


### PR DESCRIPTION
I enabled the AppVeyor build for my fork and noticed the tests were failing.